### PR TITLE
remove outdated engines setting from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js",
     "coverage": "make coverage"
   },
-  "engines": {
-    "node": ">=0.10.0 <=5.x.x"
-  },
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/balderdashy/waterline/issues/new"


### PR DESCRIPTION
This PR just removes the engine setting from package.json since it's way outdated and we aren't maintaining it.